### PR TITLE
Allow users of chart to override operator image

### DIFF
--- a/helm/charts/3.0.0-final/templates/deployment.yaml
+++ b/helm/charts/3.0.0-final/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               fieldPath: "metadata.namespace"
         - name: "QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES"
           value: {{ .Values.watchNamespaces }}
-        image: "quay.io/debezium/operator:3.0.0.Final"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "Always"
         livenessProbe:
           failureThreshold: 3

--- a/helm/charts/3.0.0-final/values.yaml
+++ b/helm/charts/3.0.0-final/values.yaml
@@ -1,2 +1,6 @@
 ---
 watchNamespaces: "JOSDK_ALL_NAMESPACES"
+image:
+  registry: quay.io
+  repository: debezium/operator
+  tag: "3.0.0.Final"

--- a/helm/charts/3.0.4-final/templates/deployment.yaml
+++ b/helm/charts/3.0.4-final/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               fieldPath: "metadata.namespace"
         - name: "QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES"
           value: {{ .Values.watchNamespaces }}
-        image: "quay.io/debezium/operator:3.0.4.Final"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "Always"
         livenessProbe:
           failureThreshold: 3

--- a/helm/charts/3.0.4-final/values.yaml
+++ b/helm/charts/3.0.4-final/values.yaml
@@ -1,2 +1,6 @@
 ---
 watchNamespaces: "JOSDK_ALL_NAMESPACES"
+image:
+  registry: quay.io
+  repository: debezium/operator
+  tag: "3.0.4.Final"

--- a/helm/charts/3.0.7-final/templates/deployment.yaml
+++ b/helm/charts/3.0.7-final/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               fieldPath: "metadata.namespace"
         - name: "QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES"
           value: {{ .Values.watchNamespaces }}
-        image: "quay.io/debezium/operator:3.0.7.Final"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "Always"
         livenessProbe:
           failureThreshold: 3

--- a/helm/charts/3.0.7-final/values.yaml
+++ b/helm/charts/3.0.7-final/values.yaml
@@ -1,2 +1,6 @@
 ---
 watchNamespaces: "JOSDK_ALL_NAMESPACES"
+image:
+  registry: quay.io
+  repository: debezium/operator
+  tag: "3.0.7.Final"


### PR DESCRIPTION
This PR adds an option to override the operator image in the 3 most recent Debezium versions of the operator chart.

Tested the new versions in both of the following configurations:
- Leaving the `image.*` values overrides out to simulate how most people will be using the chart
  - Resulted in the official, Quay-hosted image being pulled for the appropriate version
- Overriding the image by providing a custom registry, repository, and tag
  - Resulted in specified image being used

If willing to merge, I will squash merge so that the unhelpful GitHub auto-generated commit messages go away from the history.